### PR TITLE
Cargo.toml: fix version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustofi"
-version = "0.3"
+version = "0.3.0"
 authors = ["Kristopher Ruzic <krruzic@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0+"


### PR DESCRIPTION
Got `error: failed to parse manifest at .../rustofi/Cargo.toml`