### PR TITLE
simple.rs: fix match

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,7 +24,7 @@ fn main() {
     loop {
         match simple_app() {
             // loop unless the user requests we exit
-            RustofiResult::Error => break,
+            RustofiResult::Error(_) => break,
             RustofiResult::Exit => break,
             RustofiResult::Cancel => break,
             RustofiResult::Blank => break,


### PR DESCRIPTION
Got the following error while trying to compile:
```sh
error[E0532]: expected unit struct, unit variant or constant, found tuple variant `RustofiResult::Error`
  --> examples/simple.rs:27:13
   |
27 |             RustofiResult::Error => break,
   |             ^^^^^^^^^^^^^^^^^^^^ did you mean `RustofiResult::Error( /* fields */ )`?
```