### PR TITLE
Add minor version number to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustofi"
-version = "0.3"
+version = "0.3.0"
 authors = ["Kristopher Ruzic <krruzic@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0+"


### PR DESCRIPTION
Newer versions of cargo require a minor version number and refuse to compile without it, giving an error:

```
error: failed to parse manifest at `/home/nom/Workspaces/sway.workspace/rustofi/Cargo.toml`

Caused by:
  unexpected end of input while parsing minor version number for key `package.version`
```